### PR TITLE
Fix installation on Codebuild CI and add version flag - #patch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/geoadmin/tool-golang-bgdi
 
-go 1.22.12
+go 1.22.10
 
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/k8s-validate/cmd/root.go
+++ b/k8s-validate/cmd/root.go
@@ -30,6 +30,14 @@ var rootCmd = &cobra.Command{
 	},
 }
 
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print the version",
+	Run: func(_ *cobra.Command, _ []string) {
+		fmt.Println(GetGitVersion())
+	},
+}
+
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
@@ -41,6 +49,8 @@ func Execute() {
 }
 
 func init() {
+	rootCmd.AddCommand(versionCmd)
+
 	// Here you will define your flags and configuration settings.
 	// Cobra supports persistent flags, which, if defined here,
 	// will be global for your application.

--- a/k8s-validate/cmd/version.go
+++ b/k8s-validate/cmd/version.go
@@ -1,0 +1,19 @@
+package cmd
+
+import (
+	"os/exec"
+	"strings"
+)
+
+// Version holds the application version
+var Version = "dev" // Fallback version
+
+// getGitVersion attempts to retrieve the latest Git tag
+func GetGitVersion() string {
+	cmd := exec.Command("git", "describe", "--tags", "--always")
+	output, err := cmd.Output()
+	if err != nil {
+		return Version // Return default if Git command fails
+	}
+	return strings.TrimSpace(string(output))
+}


### PR DESCRIPTION
Codebuild latest supported go version is 1.22.10