### PR TITLE
PB-1498: Added Assume role to e2e-tests tool and other small improvement - #minor

### DIFF
--- a/e2e-tests/cmd/common.go
+++ b/e2e-tests/cmd/common.go
@@ -51,7 +51,7 @@ func getClient(ctx context.Context, cmd *cobra.Command) *codebuild.Client {
 	}
 	var cfg aws.Config
 	if noProfile {
-		cfg, e = config.LoadDefaultConfig(ctx)
+		cfg, e = config.LoadDefaultConfig(ctx, config.WithRegion("eu-central-1"))
 	} else {
 		cfg, e = config.LoadDefaultConfig(ctx, config.WithSharedConfigProfile("swisstopo-bgdi-builder"))
 	}

--- a/e2e-tests/cmd/common.go
+++ b/e2e-tests/cmd/common.go
@@ -10,9 +10,12 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/codebuild"
 	"github.com/aws/aws-sdk-go-v2/service/codebuild/types"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/geoadmin/tool-golang-bgdi/lib/fmtc"
+	"github.com/geoadmin/tool-golang-bgdi/lib/str"
 	"github.com/spf13/cobra"
 )
 
@@ -49,15 +52,48 @@ func getClient(ctx context.Context, cmd *cobra.Command) *codebuild.Client {
 	if e != nil {
 		log.Fatal(e)
 	}
+	role := cmd.Flag("role").Value.String()
 	var cfg aws.Config
-	if noProfile {
-		cfg, e = config.LoadDefaultConfig(ctx, config.WithRegion("eu-central-1"))
-	} else {
-		cfg, e = config.LoadDefaultConfig(ctx, config.WithSharedConfigProfile("swisstopo-bgdi-builder"))
-	}
 
-	if e != nil {
-		log.Fatalf("failed to load configuration: %v", e)
+	switch {
+	case role != "":
+		var cred *sts.AssumeRoleOutput
+		cfg, e = config.LoadDefaultConfig(ctx, config.WithRegion("eu-central-1"))
+		if e != nil {
+			log.Fatalf("failed to load configuration: %v", e)
+		}
+		splittedRole := strings.Split(role, "/")
+		roleName := splittedRole[len(splittedRole)-1]
+		stsClient := sts.NewFromConfig(cfg)
+		cred, e = stsClient.AssumeRole(ctx, &sts.AssumeRoleInput{
+			RoleArn:         &role,
+			RoleSessionName: str.Ptr(fmt.Sprintf("ToolE2ETestsAssumeRole%s", roleName)),
+			DurationSeconds: aws.Int32(45 * 60), //nolint:mnd
+		})
+		if e != nil {
+			log.Fatalf("failed to assume role %s: %v", role, e)
+		}
+
+		cfg, e = config.LoadDefaultConfig(ctx, config.WithCredentialsProvider(
+			credentials.NewStaticCredentialsProvider(
+				*cred.Credentials.AccessKeyId,
+				*cred.Credentials.SecretAccessKey,
+				*cred.Credentials.SessionToken,
+			),
+		))
+		if e != nil {
+			log.Fatalf("failed to load configuration with role credentials: %v", e)
+		}
+	case noProfile:
+		cfg, e = config.LoadDefaultConfig(ctx, config.WithRegion("eu-central-1"))
+		if e != nil {
+			log.Fatalf("failed to load configuration: %v", e)
+		}
+	default:
+		cfg, e = config.LoadDefaultConfig(ctx, config.WithSharedConfigProfile("swisstopo-bgdi-builder"))
+		if e != nil {
+			log.Fatalf("failed to load configuration: %v", e)
+		}
 	}
 
 	client := codebuild.NewFromConfig(cfg)

--- a/e2e-tests/cmd/completions/tests.go
+++ b/e2e-tests/cmd/completions/tests.go
@@ -6,6 +6,7 @@ import (
 	"os/user"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -13,19 +14,34 @@ import (
 
 //-----------------------------------------------------------------------------
 
-func FindTests(_ *cobra.Command, _ []string, _ string) ([]cobra.Completion, cobra.ShellCompDirective) {
+func CompleteTests(_ *cobra.Command, _ []string, _ string) ([]cobra.Completion, cobra.ShellCompDirective) {
 	repoPath, err := findGitRepo()
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
+	testNames, err := findTests(repoPath)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	return testNames, cobra.ShellCompDirectiveNoFileComp
+}
+
+//-----------------------------------------------------------------------------
+
+func findTests(repoPath string) ([]string, error) {
 	var testNames []string
 	repoPath = fmt.Sprintf("%s/tests", repoPath)
 
 	// Walk the repo to find test files using WalkDir
-	err = filepath.WalkDir(repoPath, func(path string, d os.DirEntry, e error) error {
-		if e != nil || d.IsDir() {
+	err := filepath.WalkDir(repoPath, func(path string, d os.DirEntry, e error) error {
+		if e != nil {
 			return e
+		}
+
+		if strings.HasSuffix(path, "__pycache__") {
+			return filepath.SkipDir
 		}
 
 		// Match test files
@@ -43,10 +59,10 @@ func FindTests(_ *cobra.Command, _ []string, _ string) ([]cobra.Completion, cobr
 		return nil
 	})
 	if err != nil {
-		return nil, cobra.ShellCompDirectiveNoFileComp
+		return nil, err
 	}
 
-	return testNames, cobra.ShellCompDirectiveNoFileComp
+	return testNames, nil
 }
 
 //-----------------------------------------------------------------------------
@@ -63,24 +79,36 @@ func findGitRepo() (string, error) {
 	var gitRepoPath string
 
 	// Walk through the home directory to find a matching .git/config file
-	err = filepath.WalkDir(homeDir, func(path string, _ os.DirEntry, e error) error {
+	err = filepath.WalkDir(homeDir, func(path string, entry os.DirEntry, e error) error {
 		if e != nil {
 			return e
 		}
 
-		if strings.HasSuffix(path, "/.git/config") {
-			// Read the .git/config file and check if it matches the GitHub project URL
-			content, e2 := os.ReadFile(path)
-			if e2 != nil {
-				return e2
-			}
-
-			expectedURL := fmt.Sprintf("url = git@github.com:geoadmin/%s.git", gitRepo)
-			if strings.Contains(string(content), expectedURL) {
-				gitRepoPath = strings.TrimSuffix(path, "/.git/config")
-				return filepath.SkipAll // Stop searching further
-			}
+		// skip dot directory (hidden)
+		if strings.HasPrefix(entry.Name(), ".") && entry.IsDir() {
+			return filepath.SkipDir
 		}
+
+		// skip well known directory
+		if entry.IsDir() && slices.Contains([]string{
+			"node_modules",
+			"Downloads",
+			"Pictures",
+			"Music",
+			"snap",
+			"Videos",
+			"Templates",
+			"aws",
+			"go",
+		}, entry.Name()) {
+			return filepath.SkipDir
+		}
+
+		if entry.Name() == "infra-e2e-tests" {
+			gitRepoPath = path
+			return filepath.SkipAll
+		}
+
 		return nil // continue walking
 	})
 	if err != nil {

--- a/e2e-tests/cmd/get.go
+++ b/e2e-tests/cmd/get.go
@@ -36,6 +36,11 @@ Note that if the tests run is on-going, the command waits until its is finished.
 		if e != nil {
 			log.Fatal(e)
 		}
+		np, e := cmd.Flags().GetBool("no-progress")
+		if e != nil {
+			log.Fatal(e)
+		}
+		showProgress := !np
 
 		input := &codebuild.BatchGetBuildsInput{
 			Ids: []string{id},
@@ -50,7 +55,7 @@ Note that if the tests run is on-going, the command waits until its is finished.
 		}
 		if !r.Builds[0].BuildComplete {
 			cPrintln(fmtc.NoColor, "E2E Tests run found, run in progress waiting to complete...")
-			r = waitForBuild(ctx, client, id)
+			r = waitForBuild(ctx, client, id, showProgress)
 		} else {
 			cPrintf(fmtc.NoColor, "E2E Tests run found and completed at %s\n", r.Builds[0].EndTime.UTC().String())
 		}

--- a/e2e-tests/cmd/get.go
+++ b/e2e-tests/cmd/get.go
@@ -64,6 +64,10 @@ Note that if the tests run is on-going, the command waits until its is finished.
 			log.Fatalf("failed to print test reports: %s", e)
 		}
 	},
+	ValidArgsFunction: func(_ *cobra.Command, _ []string, _ string) ([]cobra.Completion, cobra.ShellCompDirective) {
+		// Avoid doing file/folder completion after the command
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	},
 }
 
 //-----------------------------------------------------------------------------

--- a/e2e-tests/cmd/root.go
+++ b/e2e-tests/cmd/root.go
@@ -48,6 +48,7 @@ func init() {
 	rootCmd.PersistentFlags().Bool("no-color", false, "Do not use color in output")
 	rootCmd.PersistentFlags().Bool("no-profile", false, "Do not use AWS profile swisstopo-bgdi-builder for credentials")
 	rootCmd.PersistentFlags().String("role", "", "Role to assume for AWS permissions")
+	rootCmd.PersistentFlags().Bool("no-progress", false, "For long running command don't display progress indicator")
 
 	// Add completion command
 	rootCmd.AddCommand(&cobra.Command{

--- a/e2e-tests/cmd/root.go
+++ b/e2e-tests/cmd/root.go
@@ -49,35 +49,6 @@ func init() {
 	rootCmd.PersistentFlags().Bool("no-profile", false, "Do not use AWS profile swisstopo-bgdi-builder for credentials")
 	rootCmd.PersistentFlags().String("role", "", "Role to assume for AWS permissions")
 	rootCmd.PersistentFlags().Bool("no-progress", false, "For long running command don't display progress indicator")
-
-	// Add completion command
-	rootCmd.AddCommand(&cobra.Command{
-		Use:   "completion [bash|zsh|fish|powershell]",
-		Short: "Generate shell completion script",
-		Args:  cobra.ExactArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
-			switch args[0] {
-			case "bash":
-				if err := rootCmd.GenBashCompletion(os.Stdout); err != nil {
-					cmd.PrintErrln("Error generating Bash completion:", err)
-				}
-			case "zsh":
-				if err := rootCmd.GenZshCompletion(os.Stdout); err != nil {
-					cmd.PrintErrln("Error generating Zsh completion:", err)
-				}
-			case "fish":
-				if err := rootCmd.GenFishCompletion(os.Stdout, true); err != nil {
-					cmd.PrintErrln("Error generating Fish completion:", err)
-				}
-			case "powershell":
-				if err := rootCmd.GenPowerShellCompletionWithDesc(os.Stdout); err != nil {
-					cmd.PrintErrln("Error generating PowerShell completion:", err)
-				}
-			default:
-				cmd.PrintErrln("Unsupported shell type")
-			}
-		},
-	})
 }
 
 //-----------------------------------------------------------------------------

--- a/e2e-tests/cmd/root.go
+++ b/e2e-tests/cmd/root.go
@@ -47,6 +47,7 @@ func init() {
 
 	rootCmd.PersistentFlags().Bool("no-color", false, "Do not use color in output")
 	rootCmd.PersistentFlags().Bool("no-profile", false, "Do not use AWS profile swisstopo-bgdi-builder for credentials")
+	rootCmd.PersistentFlags().String("role", "", "Role to assume for AWS permissions")
 
 	// Add completion command
 	rootCmd.AddCommand(&cobra.Command{

--- a/e2e-tests/cmd/start.go
+++ b/e2e-tests/cmd/start.go
@@ -40,6 +40,10 @@ var startCmd = &cobra.Command{
 
 		printTestResult(ctx, client, re)
 	},
+	ValidArgsFunction: func(_ *cobra.Command, _ []string, _ string) ([]cobra.Completion, cobra.ShellCompDirective) {
+		// Avoid doing file/folder completion after the command
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	},
 }
 
 //-----------------------------------------------------------------------------

--- a/e2e-tests/cmd/start.go
+++ b/e2e-tests/cmd/start.go
@@ -60,7 +60,7 @@ func init() {
 		) {
 			return []cobra.Completion{"dev", "int", "prod"}, cobra.ShellCompDirectiveDefault
 		})
-	_ = startCmd.RegisterFlagCompletionFunc("tests", completions.FindTests)
+	_ = startCmd.RegisterFlagCompletionFunc("tests", completions.CompleteTests)
 }
 
 //-----------------------------------------------------------------------------

--- a/k8s-validate/cmd/root.go
+++ b/k8s-validate/cmd/root.go
@@ -65,33 +65,4 @@ func init() {
 By default it is set to 0 which means that it use the number of available CPU
 to determine how many parallel jobs are executed.`,
 	)
-
-	// Add completion command
-	rootCmd.AddCommand(&cobra.Command{
-		Use:   "completion [bash|zsh|fish|powershell]",
-		Short: "Generate shell completion script",
-		Args:  cobra.ExactArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
-			switch args[0] {
-			case "bash":
-				if err := rootCmd.GenBashCompletion(os.Stdout); err != nil {
-					cmd.PrintErrln("Error generating Bash completion:", err)
-				}
-			case "zsh":
-				if err := rootCmd.GenZshCompletion(os.Stdout); err != nil {
-					cmd.PrintErrln("Error generating Zsh completion:", err)
-				}
-			case "fish":
-				if err := rootCmd.GenFishCompletion(os.Stdout, true); err != nil {
-					cmd.PrintErrln("Error generating Fish completion:", err)
-				}
-			case "powershell":
-				if err := rootCmd.GenPowerShellCompletionWithDesc(os.Stdout); err != nil {
-					cmd.PrintErrln("Error generating PowerShell completion:", err)
-				}
-			default:
-				cmd.PrintErrln("Unsupported shell type")
-			}
-		},
-	})
 }


### PR DESCRIPTION
 To allow to use the tool in a cross account scenario we need to be able to  assume a role.

Aslo added progress informations.