### PR TITLE
PB-1570: Added e2e-tests --interval option - #minor

### DIFF
--- a/e2e-tests/cmd/common.go
+++ b/e2e-tests/cmd/common.go
@@ -108,6 +108,7 @@ func waitForBuild(
 	client *codebuild.Client,
 	buildID string,
 	showProgress bool,
+	interval int,
 ) *codebuild.BatchGetBuildsOutput {
 	var result *codebuild.BatchGetBuildsOutput
 	var e error
@@ -117,12 +118,11 @@ func waitForBuild(
 	}
 	c := 0
 	for {
-		const waitTime = 1
 		if showProgress {
 			cPrintf(fmtc.NoColor, "\rWating for result: %ds ", c)
-			c += waitTime
+			c += interval
 		}
-		time.Sleep(waitTime * time.Second)
+		time.Sleep(time.Duration(interval) * time.Second)
 		result, e = client.BatchGetBuilds(ctx, input)
 		if e != nil {
 			log.Fatalf("failed to get build status: %v", e)

--- a/e2e-tests/cmd/get.go
+++ b/e2e-tests/cmd/get.go
@@ -41,6 +41,10 @@ Note that if the tests run is on-going, the command waits until its is finished.
 			log.Fatal(e)
 		}
 		showProgress := !np
+		interval, e := cmd.Flags().GetInt("interval")
+		if e != nil {
+			log.Fatal(e)
+		}
 
 		input := &codebuild.BatchGetBuildsInput{
 			Ids: []string{id},
@@ -55,7 +59,7 @@ Note that if the tests run is on-going, the command waits until its is finished.
 		}
 		if !r.Builds[0].BuildComplete {
 			cPrintln(fmtc.NoColor, "E2E Tests run found, run in progress waiting to complete...")
-			r = waitForBuild(ctx, client, id, showProgress)
+			r = waitForBuild(ctx, client, id, showProgress, interval)
 		} else {
 			cPrintf(fmtc.NoColor, "E2E Tests run found and completed at %s\n", r.Builds[0].EndTime.UTC().String())
 		}

--- a/e2e-tests/cmd/root.go
+++ b/e2e-tests/cmd/root.go
@@ -49,6 +49,7 @@ func init() {
 	rootCmd.PersistentFlags().Bool("no-profile", false, "Do not use AWS profile swisstopo-bgdi-builder for credentials")
 	rootCmd.PersistentFlags().String("role", "", "Role to assume for AWS permissions")
 	rootCmd.PersistentFlags().Bool("no-progress", false, "For long running command don't display progress indicator")
+	rootCmd.PersistentFlags().Int("interval", 1, "Interval in seconds to check the E2E tests status")
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
When starting the E2E tests from ArgoCD we might have this command run
in parallel from a lots of application triggering a lots of GetBuildBatch
and we end up in an `api error ThrottlingException: Rate exceeded: BatchGetBuilds`

To avoid this, introducing a configurable interval between each BatchGetBuilds