### PR TITLE
PB-1502: Fixed e2e-tests command exit code and --tests option - #patch

### DIFF
--- a/e2e-tests/Dockerfile
+++ b/e2e-tests/Dockerfile
@@ -1,6 +1,6 @@
 # Generic docker file for all tools that needs to be build
 # Use an official Golang image as the base
-FROM golang:1.23 AS builder
+FROM golang:1.23.8 AS builder
 
 WORKDIR /tool
 

--- a/e2e-tests/cmd/common.go
+++ b/e2e-tests/cmd/common.go
@@ -157,6 +157,8 @@ func printTestResult(ctx context.Context, client *codebuild.Client, result *code
 			log.Fatal(e)
 		}
 	}
+	// For E2E tests error we use exit code 2 to differentiate between e2e-tests command failure
+	os.Exit(2) //nolint:mnd
 }
 
 //-----------------------------------------------------------------------------

--- a/e2e-tests/cmd/start.go
+++ b/e2e-tests/cmd/start.go
@@ -88,6 +88,15 @@ func getFlags(cmd *cobra.Command) (string, []string, string, bool, bool, int) {
 		log.Fatal(err)
 	}
 	tests, err := cmd.Flags().GetStringArray("tests")
+	// Append the "tests." prefix to all tests
+	tests = func() []string {
+		out := make([]string, len(tests))
+		for i, t := range tests {
+			out[i] = "tests." + t
+		}
+		return out
+	}()
+
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/geoadmin/tool-golang-bgdi
 
-go 1.22.10
+go 1.23.8
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.36.3


### PR DESCRIPTION
The tests options did not work due to missing "tests." prefix.

The command always returned 0 even if the tests failed. In order to use it
in a script where we need to know if the tests pass we need a proper exit code.