### PR TITLE
Improved e2e-tests failure reports - #minor

### DIFF
--- a/e2e-tests/cmd/get.go
+++ b/e2e-tests/cmd/get.go
@@ -17,6 +17,15 @@ import (
 
 //-----------------------------------------------------------------------------
 
+type GetCmdFlags struct {
+	TestID       string
+	Detailed     bool
+	ShowProgress bool
+	Interval     int
+}
+
+//-----------------------------------------------------------------------------
+
 // getCmd represents the get command
 var getCmd = &cobra.Command{
 	Use:   "get",
@@ -30,6 +39,11 @@ Note that if the tests run is on-going, the command waits until its is finished.
 			return e
 		}
 
+		flags, e := getCmdGetFlags(cmd)
+		if e != nil {
+			return e
+		}
+
 		ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 		defer stop() // Ensure cleanup
 
@@ -38,34 +52,20 @@ Note that if the tests run is on-going, the command waits until its is finished.
 			return e
 		}
 
-		id, e := cmd.Flags().GetString("test-id")
-		if e != nil {
-			return e
-		}
-		np, e := cmd.Flags().GetBool("no-progress")
-		if e != nil {
-			return e
-		}
-		showProgress := !np
-		interval, e := cmd.Flags().GetInt("interval")
-		if e != nil {
-			return e
-		}
-
 		input := &codebuild.BatchGetBuildsInput{
-			Ids: []string{id},
+			Ids: []string{flags.TestID},
 		}
 		r, e := client.BatchGetBuilds(ctx, input)
 		if e != nil {
-			return fmt.Errorf("failed to get tests run %s: %w", id, e)
+			return fmt.Errorf("failed to get tests run %s: %w", flags.TestID, e)
 		}
 
 		if len(r.Builds) == 0 {
-			return fmt.Errorf("failed to get tests run %s: not found", id)
+			return fmt.Errorf("failed to get tests run %s: not found", flags.TestID)
 		}
 		if !r.Builds[0].BuildComplete {
 			cPrintln(fmtc.NoColor, "E2E Tests run found, run in progress waiting to complete...")
-			r, e = waitForBuild(ctx, client, id, showProgress, interval)
+			r, e = waitForBuild(ctx, client, flags.TestID, flags.ShowProgress, flags.Interval)
 			if e != nil {
 				return e
 			}
@@ -73,7 +73,7 @@ Note that if the tests run is on-going, the command waits until its is finished.
 			cPrintf(fmtc.NoColor, "E2E Tests run found and completed at %s\n", r.Builds[0].EndTime.UTC().String())
 		}
 
-		return printTestResult(ctx, client, r)
+		return printTestResult(ctx, client, r, flags.Detailed)
 	},
 	ValidArgsFunction: func(_ *cobra.Command, _ []string, _ string) ([]cobra.Completion, cobra.ShellCompDirective) {
 		// Avoid doing file/folder completion after the command
@@ -83,10 +83,42 @@ Note that if the tests run is on-going, the command waits until its is finished.
 
 //-----------------------------------------------------------------------------
 
+func getCmdGetFlags(cmd *cobra.Command) (GetCmdFlags, error) {
+	var flags GetCmdFlags
+	id, e := cmd.Flags().GetString("test-id")
+	if e != nil {
+		return GetCmdFlags{}, e
+	}
+	flags.TestID = id
+
+	np, e := cmd.Flags().GetBool("no-progress")
+	if e != nil {
+		return GetCmdFlags{}, e
+	}
+	flags.ShowProgress = !np
+
+	interval, e := cmd.Flags().GetInt("interval")
+	if e != nil {
+		return GetCmdFlags{}, e
+	}
+	flags.Interval = interval
+
+	detailed, e := cmd.Flags().GetBool("detailed")
+	if e != nil {
+		return GetCmdFlags{}, e
+	}
+	flags.Detailed = detailed
+
+	return flags, nil
+}
+
+//-----------------------------------------------------------------------------
+
 func init() {
 	rootCmd.AddCommand(getCmd)
 
 	getCmd.Flags().StringP("test-id", "t", "", "Test ID")
+	getCmd.Flags().BoolP("detailed", "d", false, "Show detailed test result")
 	_ = getCmd.MarkFlagRequired("test-id")
 }
 


### PR DESCRIPTION
Only print failed tests, without detailed by default. Also add a short summary
of how many tests failed compared to the total tests.